### PR TITLE
Fixes zero padding calculation

### DIFF
--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -134,7 +134,7 @@ hashBytes bytes =
         -- has to be a multiple of 64 bytes (i.e. of 512 bits).
         -- The 4 is because the bitCountInBytes is supposed to be 8 long, but it's only 4 (8 - 4 = 4)
         zeroBytesToAppend =
-            4 + 64 - modBy 64 (List.length bytes + 1 + 8)
+            4 + modBy 64 (56 - modBy 64 (byteCount + 1))
 
         bytesToAppend =
             0x80 :: List.repeat zeroBytesToAppend 0x00 ++ bitCountInBytes

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -25,6 +25,7 @@ suite =
         ++ unicode
         ++ fromDevRandom
         ++ fromBytes
+        ++ weirdBytes
         |> List.map makeTest
         |> describe "SHA-1"
 
@@ -55,6 +56,14 @@ fromBytes : List TestCase
 fromBytes =
     [ TestCase (FromBytes (List.range 0 255)) "4916d6bdb7f78e6803698cab32d1586ea457dfc8" "SRbWvbf3jmgDaYyrMtFYbqRX38g="
     , TestCase (FromBytes (List.repeat 200000 184)) "707d33fe36b8bf5d21568058370ad9b70c5d1bfc" "cH0z/ja4v10hVoBYNwrZtwxdG/w="
+    ]
+
+
+weirdBytes : List TestCase
+weirdBytes =
+    [ TestCase (FromBytes (List.repeat 64 54 ++ List.repeat 310 46)) "08afccd24bce328ae74661653ca103df02cba690" "CK/M0kvOMornRmFlPKED3wLLppA="
+    , TestCase (FromBytes (List.repeat 64 54 ++ List.repeat 311 46)) "bd8b2089549d57a05becbace5112c2c593b1af8b" "vYsgiVSdV6Bb7LrOURLCxZOxr4s="
+    , TestCase (FromBytes (List.repeat 64 54 ++ List.repeat 312 46)) "c6045cfc2468675660d3ff788225229c6b7ab422" "xgRc/CRoZ1Zg0/94giUinGt6tCI="
     ]
 
 


### PR DESCRIPTION
Per our discussion on Slack.  Includes a test that was failing (now passing).

To hunt this down I basically started implementing SHA1 on my own, and then lined it up with your code (which, btw, is way more straightforward than other implementations out there, esp. JS ones).  I couldn't figure out the zero padding calculation: `64 - modBy 64 (List.length bytes + 1 + 8)`, so I just replaced it with the formula I had ended up with: `modBy 64 (56 - modBy 64 (byteCount + 1))` and all the tests passed!  More verbosely, this calculation is:

```elm
bytesLen =
    byteCount + 1

lastChunkLen =
    modBy 64 bytesLen

zeroPadLen =
    modBy 64 (56 - lastLen)
```

###### elm-test
```
elm-test 0.19.0-rev6
--------------------

Running 36 tests. To reproduce these results, run: elm-test --fuzz 100 --seed 67610542048265 /Users/colinta/Code/elm/elm-sha1/tests/Tests.elm


TEST RUN PASSED

Duration: 1761 ms
Passed:   36
Failed:   0
```