### PR TITLE
Fixes a regression introduced in elm 0.19

### DIFF
--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -49,7 +49,7 @@ hashing [elm/bytes], [let me know][issues]!
 -}
 
 import Array exposing (Array)
-import Bitwise exposing (and, complement, or, shiftLeftBy, shiftRightZfBy, xor)
+import Bitwise exposing (and, complement, or, shiftLeftBy, shiftRightZfBy)
 import Hex
 import List.Extra exposing (groupsOf, indexedFoldl)
 import String.UTF8 as UTF8
@@ -187,7 +187,7 @@ calculateDigestDeltas index int { a, b, c, d, e } =
                 )
 
             else if index < 40 then
-                ( xor b (xor c d)
+                ( Bitwise.xor b (Bitwise.xor c d)
                 , 0x6ED9EBA1
                 )
 
@@ -197,7 +197,7 @@ calculateDigestDeltas index int { a, b, c, d, e } =
                 )
 
             else
-                ( xor b (xor c d)
+                ( Bitwise.xor b (Bitwise.xor c d)
                 , 0xCA62C1D6
                 )
     in
@@ -223,7 +223,7 @@ reduceWords index words =
         val =
             [ v 3, v 8, v 14, v 16 ]
                 |> List.filterMap identity
-                |> List.foldl xor 0
+                |> List.foldl Bitwise.xor 0
                 |> rotateLeftBy 1
     in
     Array.push val words


### PR DESCRIPTION
A regression was introduced in elm 0.19 (https://github.com/elm/compiler/issues/1945) which was fixed in the 0.19.1 alpha build presented by Evan (https://elmlang.slack.com/archives/C13L7S5GR/p1562775920080200).

This pull request fixes the build for elm 0.19.1 alpha.