### PR TITLE
elm/bytes support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 Calculate SHA-1 digests in Elm.
 
-This package can take a message as a `String` or `List Int` ("bytes") calculate
-SHA-1 digests, and represent them in [hexadecimal], [base64] or a `List Int` (as
-"bytes").
+This package supports hashing of:
+
+* `String` using the utf-8 encoding
+* `List Int` where the elements are assumed to be below 256
+* `Bytes` an `elm/bytes` sequence of byte values
+
+And can represent the digest as 
+
+* a [hexadecimal] string
+* a [base64] string
+* a `List Int` of byte values
+* a `Bytes` 
 
 [hexadecimal]: https://en.wikipedia.org/wiki/Hexadecimal
 [base64]: https://en.wikipedia.org/wiki/Base64
@@ -28,14 +37,27 @@ SHA-1 digests, and represent them in [hexadecimal], [base64] or a `List Int` (as
 ## Examples
 
 ```elm
+import Bytes.Encode as Encode
+import Bytes exposing (Bytes)
 import SHA1
 
 digest1 : SHA1.Digest
 digest1 = SHA1.fromString "string"
 
-digest2 : SHA1.Digest
-digest2 = SHA1.fromBytes [0x00, 0xFF, 0xCE, 0x35, 0x74]
+byteValues : List Int 
+byteValues = [0x00, 0xFF, 0xCE, 0x35, 0x74]
 
+digest2 : SHA1.Digest
+digest2 = SHA1.fromByteValues byteValues
+
+buffer : Bytes
+buffer = 
+    List.map Encode.unsignedInt8 byteValues
+        |> Encode.sequence
+        |> Encode.encode 
+
+digest3 : SHA1.Digest 
+digest3 = SHA1.fromBytes buffer
 
 SHA1.toHex digest1
 --> "ecb252044b5ea0f679ee78ec1a12904739e2904d"
@@ -43,11 +65,12 @@ SHA1.toHex digest1
 SHA1.toBase64 digest2
 --> "gHweOF5Lyg+Ha7ujrlYwNa/Hwgk="
 
-SHA1.toBytes digest1
---> [ 0xEC, 0xB2, 0x52, 0x04, 0x4B
---> , 0x5E, 0xA0, 0xF6, 0x79, 0xEE
---> , 0x78, 0xEC, 0x1A, 0x12, 0x90
---> , 0x47, 0x39, 0xE2, 0x90, 0x4D
+SHA1.toByteValues digest3
+--> [ 0x80, 0x7C, 0x1E, 0x38
+--> , 0x5E, 0x4B, 0xCA, 0x0F
+--> , 0x87, 0x6B, 0xBB, 0xA3
+--> , 0xAE, 0x56, 0x30, 0x35
+--> , 0xAF, 0xC7, 0xC2, 0x09
 --> ]
 ```
 

--- a/elm.json
+++ b/elm.json
@@ -1,19 +1,22 @@
 {
-  "type": "package",
-  "name": "TSFoster/elm-sha1",
-  "summary": "Generate SHA1 digests of strings or arbitrary data",
-  "license": "BSD-3-Clause",
-  "version": "1.0.4",
-  "exposed-modules": ["SHA1"],
-  "elm-version": "0.19.0 <= v < 0.20.0",
-  "dependencies": {
-    "elm/core": "1.0.0 <= v < 2.0.0",
-    "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
-    "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
-    "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
-  },
-  "test-dependencies": {
-    "elm/regex": "1.0.0 <= v < 2.0.0",
-    "elm-explorations/test": "1.2.2 <= v < 2.0.0"
-  }
+    "type": "package",
+    "name": "TSFoster/elm-sha1",
+    "summary": "Generate SHA1 digests of strings or arbitrary data",
+    "license": "BSD-3-Clause",
+    "version": "1.0.4",
+    "exposed-modules": [
+        "SHA1"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/bytes": "1.0.8 <= v < 2.0.0",
+        "elm/core": "1.0.2 <= v < 2.0.0",
+        "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
+        "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
+        "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
+    },
+    "test-dependencies": {
+        "elm/regex": "1.0.0 <= v < 2.0.0",
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+    }
 }

--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "danfishgold/base64-bytes": "1.0.2 <= v < 2.0.0",
         "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0"

--- a/elm.json
+++ b/elm.json
@@ -11,9 +11,7 @@
     "dependencies": {
         "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
-        "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
-        "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
-        "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
+        "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm/regex": "1.0.0 <= v < 2.0.0",

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -166,6 +166,7 @@ hashBytesValue bytes =
         numberOfChunks =
             Bytes.width message // 64
 
+        hashState : Decoder State
         hashState =
             iterate numberOfChunks reduceBytesMessage initialState
     in
@@ -247,13 +248,13 @@ calculateDigestDeltas index int (DeltaState (Tuple5 a b c d e)) =
         f =
             case index // 20 of
                 0 ->
-                    or (and b c) (and (Bitwise.and 0xFFFFFFFF (complement b)) d) + 0x5A827999
+                    or (and b c) (and (complement b) d) + 0x5A827999
 
                 1 ->
                     Bitwise.xor b (Bitwise.xor c d) + 0x6ED9EBA1
 
                 2 ->
-                    or (or (and b c) (and b d)) (and c d) + 0x8F1BBCDC
+                    or (and b (or c d)) (and c d) + 0x8F1BBCDC
 
                 _ ->
                     Bitwise.xor b (Bitwise.xor c d) + 0xCA62C1D6
@@ -430,3 +431,4 @@ iterateHelp n step initial =
 
     else
         initial
+

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -186,7 +186,7 @@ hashBytesValue bytes =
         -- in any case, the `Decode.andThen` fixes the issue 
         hashState : Decoder State
         hashState =
-            Decode.succeed
+            Decode.succeed ()
                 |> Decode.andThen (\_ -> iterate numberOfChunks reduceBytesMessage initialState)
     in
     case Decode.decode hashState message of

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -180,9 +180,14 @@ hashBytesValue bytes =
         numberOfChunks =
             Bytes.width message // 64
 
+        -- The `Decode.succeed ()` is required! it fixes a weird issue with large buffers 
+        -- allocating many large buffers can make SHA1 non-deterministic somehow 
+        -- (I'm not sure why that is right now, and if it's an elm problem or something deeper)
+        -- in any case, the `Decode.andThen` fixes the issue 
         hashState : Decoder State
         hashState =
-            iterate numberOfChunks reduceBytesMessage initialState
+            Decode.succeed
+                |> Decode.andThen (\_ -> iterate numberOfChunks reduceBytesMessage initialState)
     in
     case Decode.decode hashState message of
         Just (State digest) ->

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -95,7 +95,8 @@ type DeltaState
 -}
 fromString : String -> Digest
 fromString =
-    UTF8.toBytes >> hashBytes
+    -- UTF8.toBytes >> hashBytes
+    hashBytesValue << Encode.encode << Encode.string
 
 
 {-| Sometimes you have binary data that's not representable in a string. Create
@@ -110,8 +111,15 @@ and 255 are discarded.
 
 -}
 fromBytes : List Int -> Digest
-fromBytes =
-    List.filter (\i -> i >= 0 && i <= 255) >> hashBytes
+fromBytes input =
+    let
+        encode =
+            Encode.encode << Encode.sequence << List.map Encode.unsignedInt8
+    in
+    -- List.filter (\i -> i >= 0 && i <= 255) input |> hashBytes
+    input
+        |> encode
+        |> hashBytesValue
 
 
 hashBytes : List Int -> Digest

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -55,8 +55,6 @@ import Bytes exposing (Bytes, Endianness(..))
 import Bytes.Decode as Decode exposing (Decoder, Step(..))
 import Bytes.Encode as Encode
 import Hex
-import List.Extra exposing (groupsOf, indexedFoldl)
-import String.UTF8 as UTF8
 
 
 

--- a/src/SHA1.elm
+++ b/src/SHA1.elm
@@ -292,30 +292,47 @@ reduceMessage chunk (State (Tuple5 h0 h1 h2 h3 h4)) =
 calculateDigestDeltas : Int -> Int -> DeltaState -> DeltaState
 calculateDigestDeltas index int (DeltaState (Tuple5 a b c d e)) =
     let
-        ( f, k ) =
+        f =
             if index < 20 then
-                ( or (and b c) (and (trim (complement b)) d)
-                , 0x5A827999
-                )
+                or (and b c) (and (trim (complement b)) d)
 
             else if index < 40 then
-                ( Bitwise.xor b (Bitwise.xor c d)
-                , 0x6ED9EBA1
-                )
+                Bitwise.xor b (Bitwise.xor c d)
 
             else if index < 60 then
-                ( or (or (and b c) (and b d)) (and c d)
-                , 0x8F1BBCDC
-                )
+                or (or (and b c) (and b d)) (and c d)
 
             else
-                ( Bitwise.xor b (Bitwise.xor c d)
-                , 0xCA62C1D6
-                )
+                Bitwise.xor b (Bitwise.xor c d)
+
+        k =
+            if index < 20 then
+                0x5A827999
+
+            else if index < 40 then
+                0x6ED9EBA1
+
+            else if index < 60 then
+                0x8F1BBCDC
+
+            else
+                0xCA62C1D6
+
+        newA =
+            rotateLeftBy 5 a
+                |> Bitwise.and 0xFFFFFFFF
+                |> (+) f
+                |> Bitwise.and 0xFFFFFFFF
+                |> (+) e
+                |> Bitwise.and 0xFFFFFFFF
+                |> (+) k
+                |> Bitwise.and 0xFFFFFFFF
+                |> (+) int
+                |> Bitwise.and 0xFFFFFFFF
     in
     DeltaState
         (Tuple5
-            (trim (trim (trim (trim (rotateLeftBy 5 a + f) + e) + k) + int))
+            newA
             a
             (rotateLeftBy 30 b)
             c
@@ -325,7 +342,8 @@ calculateDigestDeltas index int (DeltaState (Tuple5 a b c d e)) =
 
 trim : Int -> Int
 trim =
-    and 0xFFFFFFFF
+    -- Bitwise.shiftRightZfBy 0
+    Bitwise.and 0xFFFFFFFF
 
 
 reduceWords : Int -> Array Int -> Array Int

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -98,7 +98,7 @@ x =
 
 suite : Test
 suite =
-    if False then
+    if True then
         describe "SHA-1"
             [ describe "from bytes" fromBytes
             , fromWikipedia

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -126,7 +126,7 @@ suite =
                             |> List.map Encode.unsignedInt8
                             |> Encode.sequence
                             |> Encode.encode
-                            |> SHA1.fromByte
+                            |> SHA1.fromBytes
                             |> SHA1.toHex
                             |> Expect.equal hex
         in
@@ -152,7 +152,7 @@ suite =
                 \_ ->
                     encoder
                         |> Encode.encode
-                        |> SHA1.fromByte
+                        |> SHA1.fromBytes
                         |> SHA1.toHex
                         |> Expect.equal hex
             ]
@@ -211,7 +211,7 @@ makeTestHelp input hex base64 =
 
                 FromBytes bytes ->
                     ( String.fromInt (List.length bytes) ++ " bytes"
-                    , SHA1.fromBytes bytes
+                    , SHA1.fromByteValues bytes
                     )
     in
     describe description
@@ -221,7 +221,7 @@ makeTestHelp input hex base64 =
             \_ -> Expect.equal (SHA1.toBase64 digest) base64
         , test "Raw bytes" <|
             \_ ->
-                SHA1.toBytes digest
+                SHA1.toByteValues digest
                     |> List.map (Hex.toString >> String.padLeft 2 '0')
                     |> String.concat
                     |> Expect.equal hex

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -101,6 +101,7 @@ suite =
     if True then
         describe "SHA-1"
             [ describe "from bytes" fromBytes
+            , describe "bit operations" bitoperations
             , fromWikipedia
                 ++ unicode
                 ++ fromDevRandom


### PR DESCRIPTION
This PR adds support for the `Bytes` type from `elm-bytes`, and uses that package to implement the SHA1 logic. The end result is support for `Bytes` and roughly a 10X speedup for an input of 1Kb. Hopefully, this fixes both aspects of #5 

I've tried to make small commits with descriptive messages. I'm also planning a discourse post with some more general lessons from this optimization. 

This is a big PR with changes to the public api and to most of the business logic. Two dependencies were removed (elm-utf-tools and list-extra) and one added (danfishgold/base64-bytes). I really see this as a starting point and I'm happy to not rush this PR, give more context, and make further changes. 